### PR TITLE
Add --exclude flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ tests in different environments, where some of them do not have git available.
 When running `catch-uncommitted --skip-node-versionbot-changes`, the script will
 skip checking the `package.json` & the `CHANGELOG.md` for changes, so that it
 can work as part of the balenaCI pipeline.
+
+### --exclude
+
+Custom file exclusions may be set with `catch-uncommitted --exclude`. This flag
+can be used in conjunction with other flags. For example, to skip checking a file
+located at `my/file`, use `catch-uncommitted --exclude=my/file`. Multiple files
+may be set by separating paths with a comma: `--exclude=my/file,VERSION`.

--- a/catch-uncommitted.sh
+++ b/catch-uncommitted.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 catch_no_git=0
 ignore_eol=''
-extra_args=''
+extra_args=()
 
 while [ $# -gt 0 ]; do
 	key=$1
@@ -13,10 +13,20 @@ while [ $# -gt 0 ]; do
 			catch_no_git=1
 		;;
 		--skip-node-versionbot-changes)
-			extra_args="${extra_args} "":(exclude)package.json"" "":(exclude)package-lock.json"" "":(exclude)npm-shrinkwrap.json"" "":(exclude)CHANGELOG.md"" "":(exclude).versionbot/CHANGELOG.yml"""
+			paths=("package.json" "package-lock.json" "npm-shrinkwrap.json" "CHANGELOG.md" ".versionbot/CHANGELOG.yml")
+			for path in "${paths[@]}"; do
+				extra_args+=(":(exclude)${path}")
+			done
 		;;
 		--ignore-space-at-eol)
 			ignore_eol="--ignore-space-at-eol"
+		;;
+		--exclude=*)
+			while IFS=',' read -ra paths; do
+				for path in "${paths[@]}"; do
+					extra_args+=(":(exclude)${path}")
+				done
+			done <<< "${key#--exclude=}"
 		;;
 	esac
 done
@@ -26,7 +36,7 @@ echo
 if [ $catch_no_git -eq 1 ] && !(hash git 2> /dev/null); then
 	echo "git not found, not running catch-uncommitted check"
 	exit 0
-elif ! git diff HEAD --exit-code ${ignore_eol} -- . $extra_args ; then
+elif ! git diff HEAD --exit-code ${ignore_eol} -- . "${extra_args[@]}" ; then
 	echo '** Uncommitted changes found (^^^ diff above ^^^) - FAIL **'
 	exit 1
 elif test -n "$(git ls-files --exclude-standard --others | tee /dev/tty)" ; then


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

Add an `--exclude` flag that allows users to set extra custom file paths that should be skipped when checking for uncommitted changes. Description and examples added to README.