### PR TITLE
Remove /dev/tty pipe

### DIFF
--- a/catch-uncommitted.sh
+++ b/catch-uncommitted.sh
@@ -39,7 +39,11 @@ if [ $catch_no_git -eq 1 ] && !(hash git 2> /dev/null); then
 elif ! git diff HEAD --exit-code ${ignore_eol} -- . "${extra_args[@]}" ; then
 	echo '** Uncommitted changes found (^^^ diff above ^^^) - FAIL **'
 	exit 1
-elif test -n "$(git ls-files --exclude-standard --others | tee /dev/tty)" ; then
+fi
+
+files="$(git ls-files --exclude-standard --others)"
+if test -n "$files" ; then
+	echo "$files"
 	echo '** Untracked uncommitted files found (^^^ listed above ^^^) - FAIL **'
 	exit 2
 else


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling (josh@balena.io)

---

Feel free to close this pull request if there's a good reason to keep the pipe to `/dev/tty`. I am running into an issue as described here: https://github.com/balena-io-modules/catch-uncommitted/issues/12