### PR TITLE
Add basic Yarn 2 support

### DIFF
--- a/catch-uncommitted.js
+++ b/catch-uncommitted.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const { execFileSync } = require('child_process')
+const path = require('path')
+
+const argv = process.argv.slice(2)
+
+try {
+  execFileSync(path.join(__dirname, 'catch-uncommitted.sh'), argv, {
+    stdio: 'inherit',
+  })
+} catch (error) {
+  process.exitCode = error.status
+}

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "version": "1.6.2",
   "description": "Script to catch uncommitted/unversioned files, for CI",
   "bin": {
-    "catch-uncommitted": "catch-uncommitted.sh"
+    "catch-uncommitted": "catch-uncommitted.js"
+  },
+  "engines": {
+    "node": ">=10.0.0"
   },
   "scripts": {
-    "test": "./catch-uncommitted.sh --skip-node-versionbot-changes"
+    "test": "./catch-uncommitted.js --skip-node-versionbot-changes"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As [described here](https://github.com/yarnpkg/berry/issues/882), Yarn 2 doesn't support non-JavaScript binaries. A first improvement for `catch-uncomitted`, which I believe would give us everything but Zero Installs, is to just invoke the shell script from Node.js, which this PR does.

Alternatively, to be able to support Zero Installs as well, I could port the shell script to JavaScript if you are open to the idea? Something along these lines so we don't have to introduce any external dependencies maybe?:

```js
const { execSync } = require('child_process')

const defaultOptions = {
  catchNoGit: false,
  ignoreEol: '',
  extraArgs: [],
}

const nodeVersionbotFiles = [
  'package.json',
  'package-lock.json',
  'npm-shrinkwrap.json',
  'CHANGELOG.md',
  '.versionbot/CHANGELOG.yml',
]

try {
  const userOptions = process.argv.slice(2).reduce((options, arg) => {
    switch (arg) {
      case '--catch-no-git': {
        return {
          ...options,
          catchNoGit: true,
        }
      }

      case '--skip-node-versionbot-changes': {
        return {
          ...options,
          extraArgs: [
            ...options.extraArgs,
            nodeVersionbotFiles.map((path) => `:(exclude)${path}`),
          ],
        }
      }

      default: {
        if (arg.startsWith('exclude=')) {
          return {
            ...options,
            extraArgs: [
              ...options.extraArgs,
              arg.split('=')[1], // TODO: implement correctly
            ],
          }
        }

        throw new Error(
          'usage: catch-uncommitted [--catch-no-git] [--skip-node-versionbot-changes] [--exclude=<path>]'
        )
      }
    }
  }, defaultOptions)

  if (
    userOptions.catchNoGit &&
    execSync('hash git', { stdio: 'ignore' }).length !== 0
  ) {
    throw new Error('git not found, not running catch-uncommitted check')
  }

  // TODO: continue porting along these lines...
} catch (e) {
  console.error(e.message)
  process.exit(1)
}
```